### PR TITLE
vendor/libxml: change lineNum from short to int

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libxmljs2",
-  "author": "marudor",
+  "author": "tekvel",
   "contributors": [
     "Jeff Smick",
     "Marco Rogers"
@@ -9,7 +9,7 @@
     "module_name": "xmljs",
     "module_path": "./build/Release/",
     "host": "https://github.com",
-    "remote_path": "./marudor/libxmljs2/releases/download/v{version}/",
+    "remote_path": "./tekvel/libxmljs2/releases/download/v{version}/",
     "package_name": "{node_abi}-{platform}-{arch}-{libc}.tar.gz"
   },
   "description": "libxml bindings for v8 javascript engine",
@@ -24,10 +24,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/marudor/libxmljs2.git"
+    "url": "http://github.com/tekvel/libxmljs2.git"
   },
   "bugs": {
-    "url": "http://github.com/marudor/libxmljs2/issues"
+    "url": "http://github.com/tekvel/libxmljs2/issues"
   },
   "main": "./index",
   "license": "MIT",

--- a/vendor/libxml/SAX2.c
+++ b/vendor/libxml/SAX2.c
@@ -1623,9 +1623,11 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     if (ctxt->linenumbers) {
 	if (ctxt->input != NULL) {
 	    if (ctxt->input->line < 65535)
-		ret->line = (short) ctxt->input->line;
+		ret->line16 = (short) ctxt->input->line;
 	    else
-	        ret->line = 65535;
+	        ret->line16 = 65535;
+
+	    ret->line = ctxt->input->line;
 	}
     }
 
@@ -1887,12 +1889,14 @@ skip:
     if (ctxt->linenumbers) {
 	if (ctxt->input != NULL) {
 	    if (ctxt->input->line < 65535)
-		ret->line = (short) ctxt->input->line;
+		ret->line16 = (short) ctxt->input->line;
 	    else {
-	        ret->line = 65535;
+	        ret->line16 = 65535;
 		if (ctxt->options & XML_PARSE_BIG_LINES)
 		    ret->psvi = (void *) (ptrdiff_t) ctxt->input->line;
 	    }
+
+	     ret->line = ctxt->input->line;
 	}
     }
 
@@ -2267,9 +2271,11 @@ xmlSAX2StartElementNs(void *ctx,
     if (ctxt->linenumbers) {
 	if (ctxt->input != NULL) {
 	    if (ctxt->input->line < 65535)
-		ret->line = (short) ctxt->input->line;
+		ret->line16 = (short) ctxt->input->line;
 	    else
-	        ret->line = 65535;
+	        ret->line16 = 65535;
+
+	    ret->line = ctxt->input->line;
 	}
     }
 
@@ -2689,9 +2695,11 @@ xmlSAX2ProcessingInstruction(void *ctx, const xmlChar *target,
     if (ctxt->linenumbers) {
 	if (ctxt->input != NULL) {
 	    if (ctxt->input->line < 65535)
-		ret->line = (short) ctxt->input->line;
+		ret->line16 = (short) ctxt->input->line;
 	    else
-	        ret->line = 65535;
+	        ret->line16 = 65535;
+
+	    ret->line = ctxt->input->line;
 	}
     }
     if (ctxt->inSubset == 1) {
@@ -2749,9 +2757,11 @@ xmlSAX2Comment(void *ctx, const xmlChar *value)
     if (ctxt->linenumbers) {
 	if (ctxt->input != NULL) {
 	    if (ctxt->input->line < 65535)
-		ret->line = (short) ctxt->input->line;
+		ret->line16 = (short) ctxt->input->line;
 	    else
-	        ret->line = 65535;
+	        ret->line16 = 65535;
+
+	    ret->line = ctxt->input->line;
 	}
     }
 

--- a/vendor/libxml/include/libxml/tree.h
+++ b/vendor/libxml/include/libxml/tree.h
@@ -503,8 +503,9 @@ struct _xmlNode {
     struct _xmlAttr *properties;/* properties list */
     xmlNs           *nsDef;     /* namespace definitions on this node */
     void            *psvi;	/* for type/PSVI information */
-    unsigned short   line;	/* line number */
+    unsigned short   line16;	/* line number - cut to 2 byte*/
     unsigned short   extra;	/* extra data for XPath/XSLT */
+    unsigned int   line;	/* line number */
 };
 
 /**


### PR DESCRIPTION
break libxml abi: change internal struct _xmlNode to store line number as int